### PR TITLE
Add Label Props

### DIFF
--- a/src/components/Label/Label.vue
+++ b/src/components/Label/Label.vue
@@ -13,13 +13,12 @@ const props = defineProps<LabelProps>();
 
 const labelClass = computed(() => {
     return [
-        [`label-${props.variant}`],
+        [`label-${props.variant}`], //variant of the label
     ];
 });
-
 
 </script>
 
 <style scoped lang="scss">
-@import 'style/label';
+@import 'style/_label.scss';
 </style>

--- a/src/components/Label/style/_label.scss
+++ b/src/components/Label/style/_label.scss
@@ -1,23 +1,86 @@
 .label {
-    // .required-symbol {
-    //     color: color(danger, 500);
-    //     margin-left: 2px;
-    // }
+    font-family: 'Poppins';
+    display: inline-flex;
+    padding: 0;
+    align-items: flex-start;
+    gap: 0;
 
     &-h1 {
-        font-size: 24px;
+        font-size: 35px;
+        font-style: normal;
         font-weight: 700;
-        line-height: 32px;
-        letter-spacing: 0px;
-        text-align: left;
+        line-height: 40px;
     }
     
     &-h2 {
-        font-size: 16px;
+        font-size: 29px;
+        font-style: normal;
+        font-weight: 600;
+        line-height: 32px;
+    }
+
+    &-h3 {
+        font-size: 24px;
+        font-style: normal;
         font-weight: 700;
+        line-height: 28px;
+    }
+
+    &-h4 {
+        font-size: 20px;
+        font-style: normal;
+        font-weight: 500;
         line-height: 24px;
-        letter-spacing: 0px;
-        text-align: left;
+    }
+
+    &-h5 {
+        font-size: 16px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: 20px;
+    }
+
+    &-h6 {
+        font-size: 14px;
+        font-style: normal;
+        font-weight: 600;
+        line-height: 16px;
+    }
+
+    &-h7 {
+        font-size: 12px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: 16px;
+        text-transform: uppercase;
+    }
+
+    &-h8 {
+        font-size: 12px;
+        font-style: normal;
+        font-weight: 600;
+        line-height: 16px;
+    }
+
+    &-body-bold {
+        font-size: 12px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: 16px;
+    }
+
+    &-body {
+        font-size: 12px;
+        font-style: normal;
+        font-weight: 500;
+        line-height: 16px;
+    }
+
+    &-small {
+        font-size: 11px;
+        font-style: normal;
+        font-weight: 500;
+        line-height: 16px;
     }
     
 }

--- a/src/components/Label/types/Label.ts
+++ b/src/components/Label/types/Label.ts
@@ -1,7 +1,7 @@
 export interface LabelProps {
-    text?: string;
-    variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'h7' | 'h8'; 
-    error?: boolean;
-    required?: boolean; 
-    lightdark?: boolean;
+    text?: string; //text to display
+    variant?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'h7' | 'h8' | 'body-bold' | 'body' | 'small'; //variant of the label 
+    error?: boolean; //show error message if true
+    required?: boolean; //show * if true
+    lightdark?: boolean; //toggle between light and dark mode
 }

--- a/src/components/PostCard/PostCard.vue
+++ b/src/components/PostCard/PostCard.vue
@@ -50,6 +50,7 @@
             </div>
         </div>
         <span v-if="item.isEditComment" class="post-card__divider2">Show more comments</span>
+        
     </div>
 </template>
 
@@ -57,7 +58,7 @@
 import type { PostCardProps } from './types/PostCard';
 import { ref, computed } from 'vue';
 
-const items =defineProps<{
+const items = defineProps<{
     item: PostCardProps;
     data?: boolean;
 }>();


### PR DESCRIPTION
**#Description**
Adding label props for reusable typography in the portfolio's recommendation section.

**#Types of changes**
New feature (non-breaking change that adds functionality)

**#Checklist**
- Code follows the project's coding style
- Self-reviewed the code

**#Related Tickets & Documents**
[Task 75406](https://buma.visualstudio.com/BUMA%20-%20Bspace%20Design%20System/_workitems/edit/75406): Create Label & Color Props